### PR TITLE
Update faucet-and-explorer.md

### DIFF
--- a/features/faucet-and-explorer.md
+++ b/features/faucet-and-explorer.md
@@ -10,7 +10,7 @@ The Xahau Faucet & Explorers can be found here:
     Empty body: new account (prefunded)\
     JSON body with `destination` property: fund the mentioned `destination` account.
 * **Explorers:**
-  * **Bithomp:** [**https://test.xahauexplorer.com**](https://test.xahauexplorer.com)
+  * **Xahauexplorer:** [**https://test.xahauexplorer.com**](https://test.xahauexplorer.com)
   * **XRPLF:** [**https://explorer.xahau-test.net**](https://explorer.xahau-test.net)
   * **XRPL.org:** [**https://xahau-testnet.xrpl.org**](https://xahau-testnet.xrpl.org)
   * **XRPLWin:** [**https://xahau-testnet.xrplwin.com**](https://xahau-testnet.xrplwin.com/)
@@ -19,7 +19,7 @@ The Xahau Faucet & Explorers can be found here:
 
 * **Homepage:** [**https://xahau.network**](https://xahau.network/)
 * **Explorers:**
-  * **Bithomp:** [**https://xahau.explorer.com**](https://xahauexplorer.com/)
+  * **Xahauexplorer:** [**https://xahauexplorer.com**](https://xahauexplorer.com/)
   * **Xahscan:** [**https://xahscan.com/**](https://xahscan.com/)
   * **XRPLF:** [**https://explorer.xahau.network**](https://explorer.xahau.network/)
   * **XRPL.org:** [**https://xahau.xrpl.org**](https://xahau.xrpl.org)


### PR DESCRIPTION
Bithomp changed to Xahauexplorer. Mainnet url text had a dot that doesn't exist in the real url.