### PR TITLE
docs: update MacOS build instructions

### DIFF
--- a/infrastructure/building-xahau/mac-os-13.5.2.md
+++ b/infrastructure/building-xahau/mac-os-13.5.2.md
@@ -116,7 +116,7 @@ Install Boost
 
 ```
 cd $DEP_DIR && \
-wget https://boostorg.jfrog.io/artifactory/main/release/$BOOST_VERSION/source/$BOOST_FOLDER_NAME.tar.gz && \
+wget https://archives.boost.io/release/$BOOST_VERSION/source/$BOOST_FOLDER_NAME.tar.gz && \
 tar -xvzf $BOOST_FOLDER_NAME.tar.gz && \
 cd $BOOST_FOLDER_NAME && \
 ./bootstrap.sh && \
@@ -126,6 +126,8 @@ cd $BOOST_FOLDER_NAME && \
 Install WasmEdge
 
 ```
+# You will need to edit the CMakesList.txt to update the boost dependency url to use a new prefix
+# "https://archives.boost.io/release/" due to https://github.com/boostorg/boost/issues/843#issuecomment-2567034014
 cd $DEP_DIR && \
 wget -nc -q https://github.com/WasmEdge/WasmEdge/archive/refs/tags/$WASMEDGE_VERSION.zip && \
 unzip -o $WASMEDGE_VERSION.zip && \

--- a/infrastructure/building-xahau/mac-os-13.5.2.md
+++ b/infrastructure/building-xahau/mac-os-13.5.2.md
@@ -1,14 +1,22 @@
 # Mac OS - 15.0.1
 
-| Dependency  | Working Version |
-| ----------- | --------------- |
-| Apple Clang | 14.3.1          |
-| LLVM        | 14              |
-| LLD         | 14              |
-| Boost       | 1.86.0          |
-| CMake       | 3.23.1          |
-| Protobuf    | 3.20.0          |
-| WasmEdge    | 0.11.2          |
+| Dependency  | Working Versions |
+|-------------|------------------|
+| Apple Clang | 14.3.1, 16.0.0   |
+| LLVM        | 14               |
+| LLD         | 14               |
+| Boost       | 1.86.0           |
+| CMake       | 3.23.1           |
+| Protobuf    | 3.20.0           |
+| WasmEdge    | 0.11.2           |
+
+### Using Clang 16.0.0
+
+The XCode that matches MacOS Sequoia 15.3 bundles Clang 16.0.0. It has a performance regression
+when instantiating templates from large enum ranges.
+
+If you experience any hanging compiles, make sure you to merge the following PR:
+https://github.com/Xahau/xahaud/pull/436
 
 ### Force Apple Clang 14.3.1
 
@@ -112,6 +120,12 @@ make -j$(sysctl -n hw.logicalcpu) && \
 sudo make install
 ```
 
+{% hint style="info" %}
+Note that it's currently necessary to remove any homebrew installations of protobuf otherwise
+cmake will mix up both installations. There would of course be better workarounds for this, 
+but simply removing the homebrew installations is a quick fix.
+{% endhint %}
+
 Install Boost
 
 ```
@@ -126,12 +140,12 @@ cd $BOOST_FOLDER_NAME && \
 Install WasmEdge
 
 ```
-# You will need to edit the CMakesList.txt to update the boost dependency url to use a new prefix
-# "https://archives.boost.io/release/" due to https://github.com/boostorg/boost/issues/843#issuecomment-2567034014
 cd $DEP_DIR && \
 wget -nc -q https://github.com/WasmEdge/WasmEdge/archive/refs/tags/$WASMEDGE_VERSION.zip && \
 unzip -o $WASMEDGE_VERSION.zip && \
 cd WasmEdge-$WASMEDGE_VERSION && \
+sed -i '' \
+  's|https://boostorg\.jfrog\.io/artifactory/main/release/|https://archives.boost.io/release/|g' CMakeLists.txt && \
 mkdir build && \
 cd build && \
 cmake -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
- [x] MacOS Sequoia 15.3 / Clang 16 works 
  - [x] https://github.com/Xahau/xahaud/pull/436
- [x] JFrog boost archive is down and when using clang 14 ? or when BOOST isn't already compiled?? or something, there's a case when WasmEdge also tries to download boost, so you need to sed the CMakeLists.txt
- [x] Jfrog boost archive is down so boot install instructions need updating
- [x] Need to mention that if you have homebrew protobuf installed that it will get a mix of the homebrew library and the custom installed protoc which causes compilation errors


```
sed -i '' \
  's|https://boostorg\.jfrog\.io/artifactory/main/release/|https://archives.boost.io/release/|g' CMakeLists.txt && \
```
