### PR TITLE
docs: update build instructions to use conan

### DIFF
--- a/infrastructure/building-xahau/mac-os-13.5.2.md
+++ b/infrastructure/building-xahau/mac-os-13.5.2.md
@@ -1,186 +1,50 @@
 # Mac OS - 15.3.2 (24D81)
 
-{% hint style="warning" %}
-Xahaud now supports building using Conan. We recommend using Conan to build the repository. The build instructions for Conan can be found in the [BUILD.md](https://github.com/Xahau/xahaud/blob/dev/BUILD.md) file in the source code.
-{% endhint %}
-
-## CMake Legacy Building
-
-| Dependency  | Working Versions |
-| ----------- | ---------------- |
-| Apple Clang | 14.3.1, 16.0.0   |
-| LLVM        | 14, 16           |
-| LLD         | 14, 16           |
-| Boost       | 1.86.0           |
-| CMake       | 3.23.1           |
-| Protobuf    | 3.20.0           |
-| WasmEdge    | 0.11.2           |
-
-### Using Apple Clang 14.3.1
-
-1. Download an older version of Xcode
-   1. Go to the [https://developer.apple.com/download/more/](https://developer.apple.com/download/more/) page. You will need to sign in with your Apple Developer account.
-   2. Search for the version of Xcode that includes Apple Clang 14. This is typically specified in the release notes for each Xcode version.
-   3. Download the Xcode \`.xip\` file for the version you need.
-2. Install the older version of Xcode:
-   1. Once the download is complete, extract the \`.xip\` file, which will give you an Xcode application.
-   2. Rename this Xcode application if you want to keep multiple versions of Xcode on your system (e.g., \`Xcode\_14.3.1.app\`).
-   3. Drag the Xcode application to your \`/Applications\` directory.
-3. Switch to the desired version of the toolchain
-   1.  If you want to use the newly installed version of Xcode and its toolchain by default, you can switch to it using the \`xcode-select\` command:
-
-       ```
-       sudo xcode-select -s /Applications/Xcode_14.3.1.app/Contents/Developer
-       ```
-   2. Replace \`Xcode\_14.3.1.app\` with the actual name of the Xcode version you installed.
-   3.  Open Terminal and run the following command to check the version of Clang:
-
-       `clang --version`
-
 {% hint style="info" %}
-If you want to use a specific version of Apple Clang for command line builds you can use the following;
+Xahaud now supports building using Conan. We recommend using Conan to build the repository. The detailed build instructions for Conan can be found in the [BUILD.md](https://github.com/Xahau/xahaud/blob/dev/BUILD.md) file in the source code.
 {% endhint %}
 
-```
-export DEVELOPER_DIR=/Applications/Xcode_14.3.1.app/Contents/Developer
-clang --version
-```
+## Conan Requirements
 
-### Set Build Env Variables
+| Dependency  | Minimum Version |
+| ----------- | --------------- |
+| Python      | 3.7             |
+| Conan       | 1.55            |
+| CMake       | 3.16            |
+| Apple Clang | 13.1.6          |
+| Clang       | 13              |
 
-First make a dependency directory. I like to use `~/dependencies`
+## Quick Start with Conan
 
-```
-mkdir ~/dependencies
-```
+### 1. Set Up Conan Profile
 
-Next we need to set the environment variables.
-
-### Set Version Env Variables
-
-```
-export LLVM_VERSION=14
-export BOOST_VERSION=1.86.0
-export WASMEDGE_VERSION=0.11.2
-export PROTOBUF_VERSION=3.20.0
+```bash
+conan profile new default --detect
+conan profile update settings.compiler.cppstd=20 default
 ```
 
-### Set Build Env Variables
+### 2. Export Custom Recipes (Required)
 
-```
-export DEP_DIR=~/dependencies
-export BOOST_FOLDER_NAME="boost_$(echo "$BOOST_VERSION" | sed 's/\./_/g')"
-export BOOST_ROOT="$DEP_DIR/$BOOST_FOLDER_NAME"
-export BOOST_LIBRARY_DIRS="$BOOST_ROOT/libs"
-export BOOST_INCLUDE_DIR="$BOOST_ROOT/boost"
-export BOOST_CXXFLAGS="${BOOST_CXXFLAGS:-} -DBOOST_ASIO_HAS_STD_INVOKE_RESULT"
-export LLVM_PREFIX=`brew --prefix llvm@$LLVM_VERSION`
-export LLVM_DIR="$LLVM_PREFIX/lib/cmake/llvm"
-export LLVM_LIBRARY_DIR="$LLVM_PREFIX/lib"
-export LLD_DIR="$LLVM_PREFIX/lib/cmake/lld"
-export CC=clang
-export CXX=clang++
-export LDFLAGS="${LDFLAGS:-} -L$BOOST_LIBRARY_DIRS -L$LLVM_PREFIX/lib"
-export CPPFLAGS="${CPPFLAGS:-} -I$BOOST_ROOT/include -I$LLVM_PREFIX/include"
-export CFLAGS="${CFLAGS:-} -DBOOST_ASIO_HAS_STD_INVOKE_RESULT"
-export CXXFLAGS="${CXXFLAGS:-} -DBOOST_ASIO_HAS_STD_INVOKE_RESULT"
+```bash
+conan export external/snappy snappy/1.1.10@xahaud/stable
+conan export external/soci soci/4.0.3@xahaud/stable
 ```
 
-### Install Core Dependencies
+### 3. Build
 
-```
-brew update
-brew install automake \
-             wget \
-             curl \
-             git \
-             pkg-config \
-             openssl \
-             autoconf \
-             libtool \
-             unzip \
-             cmake \
-             "llvm@$LLVM_VERSION"
+```bash
+mkdir .build && cd .build
+conan install .. --output-folder . --build missing --settings build_type=Release
+cmake -DCMAKE_TOOLCHAIN_FILE:FILEPATH=build/generators/conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release ..
+cmake --build .
 ```
 
-### Install Rippled Dependencies
+### 4. Test
 
-Install Protobuf
-
-```
-cd $DEP_DIR && \
-wget -nc https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOBUF_VERSION/protobuf-all-$PROTOBUF_VERSION.tar.gz && \
-tar -xzf protobuf-all-$PROTOBUF_VERSION.tar.gz && \
-cd protobuf-$PROTOBUF_VERSION/ && \
-./autogen.sh && \
-./configure --disable-shared link=static && \
-make -j$(sysctl -n hw.logicalcpu) && \
-sudo make install
+```bash
+./rippled --unittest
 ```
 
-{% hint style="info" %}
-Note that it's currently necessary to remove any homebrew installations of protobuf otherwise cmake will mix up both installations. There would of course be better workarounds for this, but simply removing the homebrew installations is a quick fix.
-{% endhint %}
+## Troubleshooting
 
-Install Boost
-
-```
-cd $DEP_DIR && \
-wget https://archives.boost.io/release/$BOOST_VERSION/source/$BOOST_FOLDER_NAME.tar.gz && \
-tar -xvzf $BOOST_FOLDER_NAME.tar.gz && \
-cd $BOOST_FOLDER_NAME && \
-./bootstrap.sh && \
-./b2 -j$(sysctl -n hw.logicalcpu)
-```
-
-Install WasmEdge
-
-```
-cd $DEP_DIR && \
-wget -nc -q https://github.com/WasmEdge/WasmEdge/archive/refs/tags/$WASMEDGE_VERSION.zip && \
-unzip -o $WASMEDGE_VERSION.zip && \
-cd WasmEdge-$WASMEDGE_VERSION && \
-sed -i '' \
-  's|https://boostorg\.jfrog\.io/artifactory/main/release/|https://archives.boost.io/release/|g' CMakeLists.txt && \
-mkdir build && \
-cd build && \
-cmake -DCMAKE_BUILD_TYPE=Release \
-  -DWASMEDGE_BUILD_SHARED_LIB=OFF \
-  -DWASMEDGE_BUILD_STATIC_LIB=ON \
-  -DWASMEDGE_BUILD_AOT_RUNTIME=ON \
-  -DWASMEDGE_FORCE_DISABLE_LTO=ON \
-  -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-  -DWASMEDGE_LINK_LLVM_STATIC=ON \
-  -DWASMEDGE_BUILD_PLUGINS=OFF \
-  -DWASMEDGE_LINK_TOOLS_STATIC=ON \
-  .. && \
-make -j$(sysctl -n hw.logicalcpu) && \
-sudo make install
-```
-
-### Clone the repository
-
-```
-mkdir ~/projects && \
-cd ~/projects && \
-git clone https://github.com/Xahau/xahaud.git && \
-cd xahaud && \
-git checkout dev
-```
-
-### Build Xahaud
-
-From the root `xahaud` directory:
-
-```shellscript
-mkdir build && \
-cd build && \
-cmake -DCMAKE_BUILD_TYPE=Debug -DLLVM_DIR=$LLVM_DIR -DLLVM_LIBRARY_DIR=$LLVM_LIBRARY_DIR .. && \
-cmake --build . --target rippled --parallel -j$(sysctl -n hw.logicalcpu)
-```
-
-Start the built node
-
-```
-./rippled
-```
+For detailed troubleshooting, build options, and advanced configuration, see the [BUILD.md](https://github.com/Xahau/xahaud/blob/dev/BUILD.md) file.

--- a/infrastructure/building-xahau/mac-os-13.5.2.md
+++ b/infrastructure/building-xahau/mac-os-13.5.2.md
@@ -1,8 +1,6 @@
 # Mac OS - 15.3.2 (24D81)
 
-{% hint style="info" %}
-Xahaud now supports Conan for dependency management, eliminating the need to manually build Boost, Protobuf, and other dependencies. We recommend using Conan to manage dependencies. The detailed build instructions can be found in the [BUILD.md](https://github.com/Xahau/xahaud/blob/dev/BUILD.md) file.
-{% endhint %}
+Xahaud uses Conan for dependency management. For comprehensive build instructions, see the [BUILD.md](https://github.com/Xahau/xahaud/blob/dev/BUILD.md) file in the source code.
 
 ## Requirements
 

--- a/infrastructure/building-xahau/mac-os-13.5.2.md
+++ b/infrastructure/building-xahau/mac-os-13.5.2.md
@@ -1,45 +1,71 @@
 # Mac OS - 15.3.2 (24D81)
 
 {% hint style="info" %}
-Xahaud now supports building using Conan. We recommend using Conan to build the repository. The detailed build instructions for Conan can be found in the [BUILD.md](https://github.com/Xahau/xahaud/blob/dev/BUILD.md) file in the source code.
+Xahaud now supports Conan for dependency management, eliminating the need to manually build Boost, Protobuf, and other dependencies. We recommend using Conan to manage dependencies. The detailed build instructions can be found in the [BUILD.md](https://github.com/Xahau/xahaud/blob/dev/BUILD.md) file.
 {% endhint %}
 
-## Conan Requirements
+## Requirements
 
-| Dependency  | Minimum Version |
+| Dependency  | Working Version |
 | ----------- | --------------- |
-| Python      | 3.7             |
-| Conan       | 1.55            |
-| CMake       | 3.16            |
-| Apple Clang | 13.1.6          |
-| Clang       | 13              |
+| Apple Clang | 13.1.6+        |
+| Clang       | 13+             |
+| CMake       | 3.16+           |
+| Ninja       | 1.10+ (recommended) |
+| Python      | 3.7+            |
+| Conan       | 1.55+           |
 
-## Quick Start with Conan
+## Dependency Management with Conan
 
-### 1. Set Up Conan Profile
+### Set Up Conan Profile
 
 ```bash
 conan profile new default --detect
 conan profile update settings.compiler.cppstd=20 default
 ```
 
-### 2. Export Custom Recipes (Required)
+### Export Custom Recipes (Required)
+
+Xahaud requires custom Conan recipes for Snappy and SOCI:
 
 ```bash
 conan export external/snappy snappy/1.1.10@xahaud/stable
 conan export external/soci soci/4.0.3@xahaud/stable
 ```
 
-### 3. Build
+### Install Dependencies
 
 ```bash
 mkdir .build && cd .build
 conan install .. --output-folder . --build missing --settings build_type=Release
-cmake -DCMAKE_TOOLCHAIN_FILE:FILEPATH=build/generators/conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release ..
-cmake --build .
 ```
 
-### 4. Test
+## Build with CMake
+
+### Set Build Environment Variables
+
+```bash
+export CC=clang
+export CXX=clang++
+export CFLAGS="-DBOOST_ASIO_HAS_STD_INVOKE_RESULT"
+export CXXFLAGS="-DBOOST_ASIO_HAS_STD_INVOKE_RESULT"
+```
+
+### Configure and Build (Ninja - Recommended)
+
+```bash
+cmake -G Ninja -DCMAKE_TOOLCHAIN_FILE:FILEPATH=build/generators/conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release ..
+ninja
+```
+
+### Alternative: Configure and Build (Make)
+
+```bash
+cmake -DCMAKE_TOOLCHAIN_FILE:FILEPATH=build/generators/conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release ..
+make -j$(sysctl -n hw.logicalcpu)
+```
+
+## Test
 
 ```bash
 ./rippled --unittest

--- a/infrastructure/building-xahau/ubuntu-22.04.md
+++ b/infrastructure/building-xahau/ubuntu-22.04.md
@@ -1,22 +1,23 @@
 # Ubuntu - 22.04
 
 {% hint style="info" %}
-Xahaud now supports building using Conan. We recommend using Conan to build the repository. The detailed build instructions for Conan can be found in the [BUILD.md](https://github.com/Xahau/xahaud/blob/dev/BUILD.md) file in the source code.
+Xahaud now supports Conan for dependency management, eliminating the need to manually build Boost, Protobuf, and other dependencies. We recommend using Conan to manage dependencies. The detailed build instructions can be found in the [BUILD.md](https://github.com/Xahau/xahaud/blob/dev/BUILD.md) file.
 {% endhint %}
 
-## Conan Requirements
+## Requirements
 
-| Dependency | Minimum Version |
+| Dependency | Working Version |
 | ---------- | --------------- |
-| Python     | 3.7             |
-| Conan      | 1.55            |
-| CMake      | 3.16            |
-| GCC        | 10              |
-| Clang      | 13              |
+| GCC / G++  | 10+             |
+| Clang      | 13+             |
+| CMake      | 3.16+           |
+| Ninja      | 1.10+ (recommended) |
+| Python     | 3.7+            |
+| Conan      | 1.55+           |
 
-## Quick Start with Conan
+## Dependency Management with Conan
 
-### 1. Set Up Conan Profile
+### Set Up Conan Profile
 
 ```bash
 conan profile new default --detect
@@ -24,23 +25,48 @@ conan profile update settings.compiler.cppstd=20 default
 conan profile update settings.compiler.libcxx=libstdc++11 default
 ```
 
-### 2. Export Custom Recipes (Required)
+### Export Custom Recipes (Required)
+
+Xahaud requires custom Conan recipes for Snappy and SOCI:
 
 ```bash
 conan export external/snappy snappy/1.1.10@xahaud/stable
 conan export external/soci soci/4.0.3@xahaud/stable
 ```
 
-### 3. Build
+### Install Dependencies
 
 ```bash
 mkdir .build && cd .build
 conan install .. --output-folder . --build missing --settings build_type=Release
-cmake -DCMAKE_TOOLCHAIN_FILE:FILEPATH=build/generators/conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release ..
-cmake --build .
 ```
 
-### 4. Test
+## Build with CMake
+
+### Set Build Environment Variables
+
+```bash
+export CC=gcc
+export CXX=g++
+export CFLAGS="-DBOOST_ASIO_HAS_STD_INVOKE_RESULT"
+export CXXFLAGS="-DBOOST_ASIO_HAS_STD_INVOKE_RESULT"
+```
+
+### Configure and Build (Ninja - Recommended)
+
+```bash
+cmake -G Ninja -DCMAKE_TOOLCHAIN_FILE:FILEPATH=build/generators/conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release ..
+ninja
+```
+
+### Alternative: Configure and Build (Make)
+
+```bash
+cmake -DCMAKE_TOOLCHAIN_FILE:FILEPATH=build/generators/conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release ..
+make -j$(nproc)
+```
+
+## Test
 
 ```bash
 ./rippled --unittest

--- a/infrastructure/building-xahau/ubuntu-22.04.md
+++ b/infrastructure/building-xahau/ubuntu-22.04.md
@@ -1,8 +1,6 @@
 # Ubuntu - 22.04
 
-{% hint style="info" %}
-Xahaud now supports Conan for dependency management, eliminating the need to manually build Boost, Protobuf, and other dependencies. We recommend using Conan to manage dependencies. The detailed build instructions can be found in the [BUILD.md](https://github.com/Xahau/xahaud/blob/dev/BUILD.md) file.
-{% endhint %}
+Xahaud uses Conan for dependency management. For comprehensive build instructions, see the [BUILD.md](https://github.com/Xahau/xahaud/blob/dev/BUILD.md) file in the source code.
 
 ## Requirements
 

--- a/infrastructure/building-xahau/ubuntu-22.04.md
+++ b/infrastructure/building-xahau/ubuntu-22.04.md
@@ -1,163 +1,51 @@
 # Ubuntu - 22.04
 
-{% hint style="warning" %}
-Xahaud now supports building using Conan. We recommend using Conan to build the repository. The build instructions for Conan can be found in the [BUILD.md](https://github.com/Xahau/xahaud/blob/dev/BUILD.md) file in the source code.
+{% hint style="info" %}
+Xahaud now supports building using Conan. We recommend using Conan to build the repository. The detailed build instructions for Conan can be found in the [BUILD.md](https://github.com/Xahau/xahaud/blob/dev/BUILD.md) file in the source code.
 {% endhint %}
 
-## CMake Legacy Building
+## Conan Requirements
 
-| Dependency | Working Version |
+| Dependency | Minimum Version |
 | ---------- | --------------- |
-| GCC / G++  | 14.0.3          |
-| LLVM       | 14.0.3          |
-| LLD        | 14.0.3          |
-| Boost      | 1.86.0          |
-| CMake      | 3.23.1          |
-| Protobuf   | 3.20.0          |
-| WasmEdge   | 0.11.2          |
+| Python     | 3.7             |
+| Conan      | 1.55            |
+| CMake      | 3.16            |
+| GCC        | 10              |
+| Clang      | 13              |
 
-### Set Build Env Variables
+## Quick Start with Conan
 
-First make a dependency directory. I like to use `~/dependencies`
+### 1. Set Up Conan Profile
 
-```
-mkdir ~/dependencies
-```
-
-Next we need to set the environment variables.
-
-### Set Versions Env Variables
-
-{% hint style="warning" %}
-If you are using Ubuntu 20.04 change the \`UBUNTU\_VERSION=focal\`
-{% endhint %}
-
-```
-export UBUNTU_VERSION=jammy
-export LLVM_VERSION=14
-export CMAKE_VERSION=3.23.1
-export BOOST_VERSION=1.86.0
-export WASMEDGE_VERSION=0.11.2
-export PROTOBUF_VERSION=3.20.0
+```bash
+conan profile new default --detect
+conan profile update settings.compiler.cppstd=20 default
+conan profile update settings.compiler.libcxx=libstdc++11 default
 ```
 
-### Set Build Env Variables
+### 2. Export Custom Recipes (Required)
 
-```
-export DEP_DIR=~/dependencies
-export BOOST_FOLDER_NAME="boost_$(echo "$BOOST_VERSION" | sed 's/\./_/g')"
-export BOOST_ROOT=$DEP_DIR/$BOOST_FOLDER_NAME
-export Boost_LIBRARY_DIRS=$BOOST_ROOT/libs
-export BOOST_INCLUDEDIR=$BOOST_ROOT/boost
-export Boost_INCLUDE_DIRS=$BOOST_ROOT/boost
-export LLVM_DIR=/usr/lib/llvm-$LLVM_VERSION/lib/cmake/llvm
-export LLVM_LIBRARY_DIR=/usr/lib/llvm-$LLVM_VERSION/lib
-export LLD_DIR=/usr/lib/llvm-$LLVM_VERSION/lib/cmake/lld
-export CC=gcc
-export CXX=g++
-export CFLAGS="-DBOOST_ASIO_HAS_STD_INVOKE_RESULT"
-export CXXFLAGS="-DBOOST_ASIO_HAS_STD_INVOKE_RESULT"
-export BOOST_CXXFLAGS="-DBOOST_ASIO_HAS_STD_INVOKE_RESULT"
-export LDFLAGS="-L$BOOST_ROOT/lib"
-export CPPFLAGS="-I$BOOST_ROOT/include"
-export LDFLAGS="-L/usr/lib/llvm-$LLVM_VERSION/lib"
-export CPPFLAGS="-I/usr/lib/llvm-$LLVM_VERSION/include"
+```bash
+conan export external/snappy snappy/1.1.10@xahaud/stable
+conan export external/soci soci/4.0.3@xahaud/stable
 ```
 
-### Install Core Dependencies
+### 3. Build
 
-```
-apt update && \
-apt install -y build-essential software-properties-common wget curl git pkg-config zlib1g-dev libssl-dev autoconf libtool unzip gcc g++ ninja-build && \
-wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc && \
-add-apt-repository "deb http://apt.llvm.org/$UBUNTU_VERSION/ llvm-toolchain-$UBUNTU_VERSION-$LLVM_VERSION main" && \
-add-apt-repository ppa:deadsnakes/ppa && \
-apt-cache policy python3.9 && \
-apt install -y python3.9 python3-pip llvm-$LLVM_VERSION-dev liblld-$LLVM_VERSION-dev libpolly-$LLVM_VERSION-dev
+```bash
+mkdir .build && cd .build
+conan install .. --output-folder . --build missing --settings build_type=Release
+cmake -DCMAKE_TOOLCHAIN_FILE:FILEPATH=build/generators/conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release ..
+cmake --build .
 ```
 
-{% hint style="warning" %}
-To Resolve the \``E: The repository 'http://apt.llvm.org/ llvm-toolchain-- Release` error:
-{% endhint %}
+### 4. Test
 
-```
-sudo nano /etc/apt/sources.list
-# Scroll down and remove
-deb http://apt.llvm.org/ llvm-toolchain-- main
-# Add the apt-repo directly with add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-14 main"
+```bash
+./rippled --unittest
 ```
 
-### Install Rippled Dependencies
+## Troubleshooting
 
-Install CMake
-
-```
-cd $DEP_DIR && \
-wget https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
-sudo sh cmake-$CMAKE_VERSION-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir
-```
-
-Install Protobuf
-
-```
-cd $DEP_DIR && \
-wget -nc https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOBUF_VERSION/protobuf-all-$PROTOBUF_VERSION.tar.gz && \
-tar -xzf protobuf-all-$PROTOBUF_VERSION.tar.gz && \
-cd protobuf-$PROTOBUF_VERSION/ && \
-./autogen.sh && \
-./configure --prefix=/usr --disable-shared link=static && \
-make -j$(nproc) && \
-sudo make install
-```
-
-Install Boost
-
-```
-cd $DEP_DIR && \
-wget https://boostorg.jfrog.io/artifactory/main/release/$BOOST_VERSION/source/$BOOST_FOLDER_NAME.tar.gz && \
-tar -xvzf $BOOST_FOLDER_NAME.tar.gz && \
-cd $BOOST_FOLDER_NAME && \
-./bootstrap.sh && \
-./b2 -j$(nproc)
-```
-
-Install WasmEdge
-
-```
-cd $DEP_DIR && \
-wget -nc -q https://github.com/WasmEdge/WasmEdge/archive/refs/tags/$WASMEDGE_VERSION.zip && \
-unzip -o $WASMEDGE_VERSION.zip && \
-cd WasmEdge-$WASMEDGE_VERSION && \
-mkdir build && \
-cd build && \
-cmake -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_BUILD_SHARED_LIB=OFF -DWASMEDGE_BUILD_STATIC_LIB=ON -DWASMEDGE_BUILD_AOT_RUNTIME=ON -DWASMEDGE_FORCE_DISABLE_LTO=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DWASMEDGE_LINK_LLVM_STATIC=ON -DWASMEDGE_BUILD_PLUGINS=OFF -DWASMEDGE_LINK_TOOLS_STATIC=ON .. && \
-make -j$(nproc) && \
-sudo make install
-```
-
-### Clone the repository
-
-```
-mkdir ~/projects && \
-cd ~/projects && \
-git clone https://github.com/Xahau/xahaud.git && \
-cd xahaud && \
-git checkout dev
-```
-
-### Build Xahaud
-
-From the root `xahaud` directory:
-
-```shellscript
-mkdir build && \
-cd build && \
-cmake -DCMAKE_BUILD_TYPE=Debug -DLLVM_DIR=$LLVM_DIR -DLLVM_LIBRARY_DIR=$LLVM_LIBRARY_DIR .. && \
-cmake --build . --target rippled --parallel -j$(nproc)
-```
-
-Start the built node
-
-```
-./rippled
-```
+For detailed troubleshooting, build options, and advanced configuration, see the [BUILD.md](https://github.com/Xahau/xahaud/blob/dev/BUILD.md) file.


### PR DESCRIPTION
## Summary
- Replace legacy CMake build instructions with modern Conan-based approach
- Simplify platform-specific docs to quick-start format with BUILD.md references
- Mark custom recipe exports as required steps
- Maintain platform-specific requirements for Ubuntu and macOS

## Changes
- **Ubuntu 22.04**: Updated with Conan profile setup including libstdc++11
- **macOS 15.3.2**: Updated with appropriate Conan profile for Apple platforms
- Both files now reference BUILD.md for comprehensive documentation
- Streamlined from verbose legacy instructions to concise quick-start guides

## Test plan
- [ ] Verify Conan setup steps work on Ubuntu 22.04
- [ ] Verify Conan setup steps work on macOS 15.3.2
- [ ] Confirm BUILD.md references are accessible
- [ ] Test that export steps are clearly marked as required